### PR TITLE
Allow configuring CAN bus speed

### DIFF
--- a/CANNode.cpp
+++ b/CANNode.cpp
@@ -13,9 +13,24 @@ CANNode::~CANNode() {
     }
 }
 
-void CANNode::begin() {
+void CANNode::begin(CANSpeed speed) {
     twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(_txPin, _rxPin, TWAI_MODE_NORMAL);
-    twai_timing_config_t t_config = TWAI_TIMING_CONFIG_1MBITS();
+    twai_timing_config_t t_config;
+    switch (speed) {
+        case CAN_SPEED_500KBPS:
+            t_config = TWAI_TIMING_CONFIG_500KBITS();
+            break;
+        case CAN_SPEED_250KBPS:
+            t_config = TWAI_TIMING_CONFIG_250KBITS();
+            break;
+        case CAN_SPEED_125KBPS:
+            t_config = TWAI_TIMING_CONFIG_125KBITS();
+            break;
+        case CAN_SPEED_1MBPS:
+        default:
+            t_config = TWAI_TIMING_CONFIG_1MBITS();
+            break;
+    }
     twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 
     esp_err_t res;

--- a/CANNode.h
+++ b/CANNode.h
@@ -17,12 +17,20 @@ private:
 using CANReceiveCallback = std::function<void(uint32_t, const uint8_t*, uint8_t)>;
 using CANJSONCallback = std::function<void(const String&)>;
 
+// Supported CAN bus speeds. Default is 1 Mbps.
+enum CANSpeed {
+    CAN_SPEED_1MBPS,
+    CAN_SPEED_500KBPS,
+    CAN_SPEED_250KBPS,
+    CAN_SPEED_125KBPS
+};
+
 class CANNode {
 public:
     CANNode(uint32_t address, gpio_num_t txPin, gpio_num_t rxPin);
     ~CANNode();
 
-    void begin();
+    void begin(CANSpeed speed = CAN_SPEED_1MBPS);
     void send(const uint8_t* data, uint8_t len);
     bool receive(uint32_t& identifier, uint8_t* data, uint8_t& len, uint32_t timeoutMs = 100);
 

--- a/examples/BasicSendReceive/BasicSendReceive.ino
+++ b/examples/BasicSendReceive/BasicSendReceive.ino
@@ -34,6 +34,7 @@ void setup() {
 
   Serial.println("[INIT] Starting CANNode...");
   try {
+    // Starts at 1 Mbps by default. Pass a CANSpeed to change it, e.g. CAN_SPEED_500KBPS
     canNode.begin();
     canNode.setReceiveCallback(onReceive);
     Serial.println("[INIT] CANNode started!");


### PR DESCRIPTION
## Summary
- add CANSpeed enum to select bitrate
- allow `CANNode::begin` to accept desired speed with 1 Mbps default
- document speed selection in example

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ab812f94cc832db21d6ea8f5d05212